### PR TITLE
jshint task reports fails to process exit code

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,8 @@ gulp.task('jscs', function() {
 gulp.task('jshint', function() {
   return gulp.src(SOURCE_FOLDERS)
     .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe(jshint.reporter('default'))
+    .pipe(jshint.reporter('fail'));
 });
 
 //


### PR DESCRIPTION
This allow Continous Deployment tasks to fail if jshint validation fails
